### PR TITLE
Support any typescript >= 2.6.1 and < 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/EmandM/ts-mock-imports",
   "peerDependencies": {
-    "typescript": ">=2.6.1 < 3.2",
+    "typescript": ">=2.6.1 < 4",
     "sinon": ">= 4.1.2 < 7"
   },
   "scripts": {


### PR DESCRIPTION
Gets rid of this warning when using newest versions of Typescript...

<img width="681" alt="Screen Shot 2019-05-12 at 7 58 01 PM" src="https://user-images.githubusercontent.com/11083871/57590283-62331a00-74f0-11e9-9425-df8c4fefe6af.png">
