### PR TITLE
Move `sinon` to `dependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
   },
   "homepage": "https://github.com/EmandM/ts-mock-imports",
   "peerDependencies": {
-    "typescript": ">=2.6.1 < 4",
-    "sinon": ">= 4.1.2 < 7"
+    "typescript": ">=2.6.1 < 4"
   },
   "scripts": {
     "dtslint": "dtslint test/types",
@@ -39,7 +38,9 @@
     "test": "npm run dtslint && npm run unit-test",
     "compile": "rimraf lib && ./node_modules/.bin/tsc -p ./src"
   },
-  "dependencies": {},
+  "dependencies": {
+     "sinon": "^5.0.10"
+  },
   "devDependencies": {
     "@types/chai": "^4.1.3",
     "@types/mocha": "^5.2.0",
@@ -51,7 +52,6 @@
     "dtslint": "^0.3.0",
     "mocha": "^5.2.0",
     "rimraf": "^2.6.2",
-    "sinon": "^5.0.10",
     "ts-node": "^6.0.5",
     "tslint": "^5.11.0",
     "tslint-config-airbnb": "^5.11.0",


### PR DESCRIPTION
Moves the required dependency `sinon` to the `dependencies` block in `package.json`. 

This allows `ts-mock-imports` to work out of the box.