### PR TITLE
Made replaceFunction public

### DIFF
--- a/src/managers/mock-manager.ts
+++ b/src/managers/mock-manager.ts
@@ -36,7 +36,7 @@ export class MockManager<T> extends Manager {
     return spy;
   }
 
-  protected replaceFunction(funcName: string, newFunc: () => any) {
+  public replaceFunction(funcName: string, newFunc: () => any) {
     this.replace(funcName, newFunc);
   }
 


### PR DESCRIPTION
By making replaceFunction public we can add functions that throw exceptions for better testing